### PR TITLE
Expose synchronous parse function without data fetching

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,11 @@ import MicrodataScraper from './scrapers/MicrodataScraper';
 import JsonLdScraper from './scrapers/JsonLdScraper';
 import logger from './utils/logger';
 
-const errorMessage = 'Could not find recipe data';
+export const errors = {
+  fetchFailed: 'Failed to fetch recipe',
+  parseFailed: 'Failed to parse recipe HTML',
+  noRecipeFound: 'Could not find recipe data',
+}
 
 export function parse(html, options = {}) {
   const {
@@ -12,7 +16,12 @@ export function parse(html, options = {}) {
     url,
   } = options;
 
-  const chtml = cheerio.load(html);
+  let chtml;
+  try {
+    chtml = cheerio.load(html);
+  } catch (error) {
+    throw new Error(errors.parseFailed);
+  }
 
   try {
     // attempt to find JsonLd data, return recipe or log and continue
@@ -57,21 +66,17 @@ export function parse(html, options = {}) {
   // could add a Scraper for rdfa in the future
 
   // throw if no recipe found
-  throw new Error(errorMessage);
+  throw new Error(errors.noRecipeFound);
 }
 
 export default async (url, options = {}) => {
-  const {
-    printToConsole,
-  } = options;
-
   let resp;
 
   try {
     // load html from scraped url
     resp = await axios(url);
   } catch (error) {
-    throw new Error(errorMessage);
+    throw new Error(errors.fetchFailed);
   }
 
   return parse(resp.data, {

--- a/src/main.js
+++ b/src/main.js
@@ -6,20 +6,13 @@ import logger from './utils/logger';
 
 const errorMessage = 'Could not find recipe data';
 
-export default async (url, options = {}) => {
+export function parse(html, options = {}) {
   const {
     printToConsole,
+    url,
   } = options;
 
-  let chtml;
-
-  try {
-    // load html from scraped url
-    const resp = await axios(url);
-    chtml = cheerio.load(resp.data);
-  } catch (error) {
-    throw new Error(errorMessage);
-  }
+  const chtml = cheerio.load(html);
 
   try {
     // attempt to find JsonLd data, return recipe or log and continue
@@ -65,4 +58,24 @@ export default async (url, options = {}) => {
 
   // throw if no recipe found
   throw new Error(errorMessage);
+}
+
+export default async (url, options = {}) => {
+  const {
+    printToConsole,
+  } = options;
+
+  let resp;
+
+  try {
+    // load html from scraped url
+    resp = await axios(url);
+  } catch (error) {
+    throw new Error(errorMessage);
+  }
+
+  return parse(resp.data, {
+    url,
+    ...options,
+  })
 };


### PR DESCRIPTION
1. Expose synchronous parse function without data fetching. This allows the user to bring their own data, for example if they'll do other kinds of processing of the HTML.
2. Update error messages to be clearer about failure cases. Now, fetch error, parse error, and missing data have unique error messages.

I'll add tests for the new behavior if the idea of this change is accepted.